### PR TITLE
Remove disable-passwdmgr.inc

### DIFF
--- a/firejailed-tor-browser.profile
+++ b/firejailed-tor-browser.profile
@@ -56,7 +56,6 @@ include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
 include disable-interpreters.inc
-include disable-passwdmgr.inc
 include disable-programs.inc
 include disable-shell.inc
 include disable-xdg.inc


### PR DESCRIPTION
Due to https://github.com/netblue30/firejail/pull/4461, `/etc/firejail/disable-passwdmgr.inc` no longer exists, thus including it in `firejailed-tor-browser.profile` causes Tor Browser to crash.