### PR TITLE
Support dash and fix backports

### DIFF
--- a/_common.sh
+++ b/_common.sh
@@ -26,7 +26,7 @@ FTB_DESKTOP_DEST="${XDG_DATA_HOME:-"$HOME"/.local/share}/applications/$FTB_DESKT
 FTB_LOCAL="firejailed-tor-browser.local"
 FTB_PROFILE="firejailed-tor-browser.profile"
 FTB_X11_INC="firejailed-tor-browser-x11.inc"
-SUPPORTED_FIREJAIL_VERSIONS=("git" "0.9.64.4" "0.9.62" "0.9.58" "0.9.52")
+SUPPORTED_FIREJAIL_VERSIONS=("git" "0.9.66" "0.9.64.4" "0.9.62" "0.9.58" "0.9.52")
 
 CFG_FIREJAIL_VERSION="git"
 CFG_SRC="."

--- a/firejailed-tor-browser.profile
+++ b/firejailed-tor-browser.profile
@@ -45,8 +45,7 @@ ignore noexec ${HOME}
 
 noblacklist ${HOME}/.firejailed-tor-browser
 
-noblacklist ${PATH}/bash
-noblacklist ${PATH}/sh
+include allow-bin-sh.inc
 
 blacklist /etc
 blacklist /opt

--- a/stable-profiles/0.9.64.4/firejailed-tor-browser.profile
+++ b/stable-profiles/0.9.64.4/firejailed-tor-browser.profile
@@ -49,8 +49,7 @@ ignore noexec ${HOME}
 
 noblacklist ${HOME}/.firejailed-tor-browser
 
-noblacklist ${PATH}/bash
-noblacklist ${PATH}/sh
+include allow-bin-sh.inc
 
 blacklist /etc
 blacklist /opt

--- a/stable-profiles/0.9.66/firejailed-tor-browser.profile
+++ b/stable-profiles/0.9.66/firejailed-tor-browser.profile
@@ -49,8 +49,7 @@ ignore noexec ${HOME}
 
 noblacklist ${HOME}/.firejailed-tor-browser
 
-noblacklist ${PATH}/bash
-noblacklist ${PATH}/sh
+include allow-bin-sh.inc
 
 blacklist /etc
 blacklist /opt


### PR DESCRIPTION
Added support for `dash` as `/bin/sh` and added `0.9.66` to the array of backports in `_common.sh`.