### PR TITLE
Add backported profile for firejail 0.9.70

### DIFF
--- a/_common.sh
+++ b/_common.sh
@@ -26,7 +26,7 @@ FTB_DESKTOP_DEST="${XDG_DATA_HOME:-"$HOME"/.local/share}/applications/$FTB_DESKT
 FTB_LOCAL="firejailed-tor-browser.local"
 FTB_PROFILE="firejailed-tor-browser.profile"
 FTB_X11_INC="firejailed-tor-browser-x11.inc"
-SUPPORTED_FIREJAIL_VERSIONS=("git" "0.9.66" "0.9.64.4" "0.9.62" "0.9.58")
+SUPPORTED_FIREJAIL_VERSIONS=("git" "0.9.70" "0.9.66" "0.9.64.4" "0.9.62" "0.9.58")
 
 CFG_FIREJAIL_VERSION="git"
 CFG_SRC="."

--- a/stable-profiles/0.9.70/firejailed-tor-browser-x11.inc
+++ b/stable-profiles/0.9.70/firejailed-tor-browser-x11.inc
@@ -1,0 +1,3 @@
+ignore include disable-X11.inc
+ignore hostname
+include whitelist-runuser-common.inc

--- a/stable-profiles/0.9.70/firejailed-tor-browser.desktop.in
+++ b/stable-profiles/0.9.70/firejailed-tor-browser.desktop.in
@@ -1,0 +1,43 @@
+# Copyright © 2019-2022 rusty-snake and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+###########################################################
+#                                                         #
+#              HOWTO: Firejailed Tor Browser              #
+#  https://github.com/rusty-snake/firejailed-tor-browser  #
+#                                                         #
+###########################################################
+
+#
+# Backported for firejail 0.9.70
+#
+
+[Desktop Entry]
+Version=1.1
+Type=Application
+Name=Tor Browser
+GenericName=Web Browser
+Comment=Tor Browser is +1 for privacy and -1 for mass surveillance
+Icon=HOME/.firejailed-tor-browser/Browser/browser/chrome/icons/default/default128.png
+Exec=sh -c 'firejail --profile=firejailed-tor-browser "HOME/Browser/start-tor-browser" --name="Tor Browser"'
+Categories=Network;Security;WebBrowser;
+Keywords=TBB;
+StartupNotify=true
+StartupWMClass=Tor Browser

--- a/stable-profiles/0.9.70/firejailed-tor-browser.profile
+++ b/stable-profiles/0.9.70/firejailed-tor-browser.profile
@@ -1,0 +1,121 @@
+# Copyright © 2019-2022 rusty-snake and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+###########################################################
+#                                                         #
+#              HOWTO: Firejailed Tor Browser              #
+#  https://github.com/rusty-snake/firejailed-tor-browser  #
+#                                                         #
+###########################################################
+
+#
+# Backported profile for firejail 0.9.70
+#
+
+# Report any issues at
+#  <https://github.com/rusty-snake/firejailed-tor-browser/issues/new>
+
+# Persistent local customizations
+include firejailed-tor-browser.local
+
+# Note: PluggableTransports didn't work with this profile
+
+# If you use X11:
+#include firejailed-tor-browser-x11.inc
+
+# If you use pulseaudio:
+#ignore machine-id
+#noblacklist /etc
+#private-etc machine-id
+
+ignore noexec ${HOME}
+
+noblacklist ${HOME}/.firejailed-tor-browser
+
+include allow-bin-sh.inc
+
+blacklist /etc
+blacklist /opt
+blacklist /srv
+blacklist /sys
+blacklist /tmp
+blacklist /usr/games
+blacklist /usr/libexec
+blacklist /usr/local
+blacklist /usr/src
+blacklist /var
+
+include disable-common.inc
+include disable-devel.inc
+include disable-exec.inc
+include disable-interpreters.inc
+include disable-proc.inc
+include disable-programs.inc
+include disable-shell.inc
+include disable-X11.inc
+include disable-xdg.inc
+
+whitelist /run/user
+whitelist ${RUNUSER}/pulse/native
+whitelist ${RUNUSER}/wayland-0
+whitelist /usr/share/glib-2.0/schemas/gschemas.compiled
+whitelist /usr/share/icons/Adwaita
+whitelist /usr/share/mime/magic
+whitelist /usr/share/misc/magic
+whitelist /usr/share/X11/xkb
+
+caps.drop all
+hostname host
+ipc-namespace
+machine-id
+netfilter
+# Disable hardware acceleration
+#no3d
+nodvd
+nogroups
+noinput
+nonewprivs
+noroot
+# Disable sound, enable if you don't need
+#nosound
+notv
+nou2f
+novideo
+protocol unix,inet,inet6
+seccomp !chroot,@memlock,@setuid,@timer,io_pgetevents
+seccomp.block-secondary
+seccomp-error-action kill
+shell none
+
+disable-mnt
+private ${HOME}/.firejailed-tor-browser
+private-bin bash,dirname,env,expr,file,getconf,grep,rm,sh
+private-cache
+private-dev
+private-tmp
+
+dbus-user none
+dbus-system none
+
+env GTK_THEME=Adwaita
+env MOZ_ENABLE_WAYLAND=1
+name firejailed-tor-browser
+read-only ${HOME}
+read-write ${HOME}/Browser


### PR DESCRIPTION
0.9.70 (and earlier) needs `shell none` to work, so I have added a
backport.

Since 0.9.68 also needs `shell none`, how should users of that version
be instructed to use the backport for `0.9.70`? @rusty-snake do you have
a suggestion?
